### PR TITLE
Changes to periodID and KeyPeriodFilterType

### DIFF
--- a/cpix/cpix.py
+++ b/cpix/cpix.py
@@ -122,14 +122,14 @@ class CPIX(CPIXComparableBase):
                 isinstance(self.drm_systems, DRMSystemList) and
                 len(self.drm_systems) > 0):
             el.append(self.drm_systems.element())
-        if (self.usage_rules is not None and
-                isinstance(self.usage_rules, UsageRuleList) and
-                len(self.usage_rules) > 0):
-            el.append(self.usage_rules.element())
         if (self.periods is not None and
                 isinstance(self.periods, PeriodList) and
                 len(self.periods) > 0):
             el.append(self.periods.element())
+        if (self.usage_rules is not None and
+                isinstance(self.usage_rules, UsageRuleList) and
+                len(self.usage_rules) > 0):
+            el.append(self.usage_rules.element())
         return el
 
     @staticmethod

--- a/cpix/period.py
+++ b/cpix/period.py
@@ -149,7 +149,7 @@ class Period(CPIXComparableBase):
         id = xml.attrib["id"]
 
         if "index" in xml.attrib:
-            index = xml.attrib["index"]
+            index = int(xml.attrib["index"])
         else:
             index = None
         if "start" in xml.attrib:

--- a/cpix/schema/cpix.xsd
+++ b/cpix/schema/cpix.xsd
@@ -18,7 +18,7 @@
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
 	</xs:complexType>
 	<xs:complexType name="KeyPeriodFilterType">
-		<xs:attribute name="periodId" type="xs:ID" use="required"/>
+		<xs:attribute name="periodId" type="xs:IDREF" use="required"/>
 	</xs:complexType>
 	<xs:complexType name="LabelFilterType">
 		<xs:attribute name="label" type="xs:string" use="required"/>

--- a/cpix/schema/cpix.xsd
+++ b/cpix/schema/cpix.xsd
@@ -128,10 +128,20 @@
 		<xs:attribute name="id" type="xs:ID" use="optional"/>
 		<xs:attribute name="Algorithm" type="pskc:KeyAlgorithmType" use="optional"/>
 	</xs:complexType>
+	<xs:simpleType name="CencSchemeType" final="restriction">
+		<xs:restriction base="xs:string">
+			<xs:length value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="KeyIdType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:complexType name="ContentKeyType">
 		<xs:complexContent>
 			<xs:extension base="cpix:KeyType">
-				<xs:attribute name="kid" type="xs:string" use="required"/>
+				<xs:attribute name="kid" type="cpix:KeyIdType" use="required"/>
 				<xs:attribute name="explicitIV" type="xs:base64Binary" use="optional"/>
 				<xs:attribute name="dependsOnKey" type="xs:string" use="optional"/>
 				<xs:attribute name="commonEncryptionScheme" type="cpix:CencSchemeType" use="optional"/>

--- a/cpix/schema/cpix.xsd
+++ b/cpix/schema/cpix.xsd
@@ -134,6 +134,7 @@
 				<xs:attribute name="kid" type="xs:string" use="required"/>
 				<xs:attribute name="explicitIV" type="xs:base64Binary" use="optional"/>
 				<xs:attribute name="dependsOnKey" type="xs:string" use="optional"/>
+				<xs:attribute name="commonEncryptionScheme" type="cpix:CencSchemeType" use="optional"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>

--- a/cpix/usage_rule.py
+++ b/cpix/usage_rule.py
@@ -46,7 +46,7 @@ class UsageRule(CPIXListBase):
     Has required attributes:
         kid: key ID to which this rule applies
     And optional child elements:
-        KeyPeriodFilter: not currently supported
+        KeyPeriodFilter: period id based filters
         LabelFilter: not currently supported
         VideoFilter: video based filters
         AudioFilter: audio based filters


### PR DESCRIPTION
- update schema to match latest dash-if cpix schema, casting period index to int as it is a str in xml doc and updating order of elements in cpix doc as order matters
- add commonEncryptionScheme to cpix schema
- add missing cencschemetype and other diffs between this schema and the current dash-if one